### PR TITLE
fix errornous download of timestamp

### DIFF
--- a/templates/get_stage.sh
+++ b/templates/get_stage.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 latest="http://distfiles.gentoo.org/releases/amd64/autobuilds/latest-stage3.txt"
 stage3_path=$(curl  $latest 2>&1 \
-            | awk '/\/stage3-amd64-[0-9]+.tar.bz2/{print}')
+            | awk '/\/stage3-amd64-[0-9]+.tar.bz2/{print $1}')
 
 wget  {{ mirror }}/releases/amd64/autobuilds/$stage3_path -O \
       stage3.tbz2


### PR DESCRIPTION
Current stage file from http://distfiles.gentoo.org/releases/amd64/autobuilds/latest-stage3.txt looks
like:

```
20150910/stage3-amd64-20150910.tar.bz2 222693837
```

which causes the get_stage.sh to  errornously download also timestamp as http://222693837 

This patch fixes above problem.
